### PR TITLE
Fully merge of Behat/MinkWUnitDriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,18 @@
     ],
 
     "require": {
-        "php":          ">=5.3.2",
-        "behat/behat":  ">=2.4.0,<2.4.x-dev"
+        "php":                     ">=5.3.2",
+        "symfony/http-foundation": ">=2.0,<2.4-dev",
+        "behat/behat":             ">=2.4.1,<2.4.x-dev",
+		"behat/mink":              "1.4.*"
     },
 
     "autoload": {
-        "psr-0": { "Behat\\YiiExtension": "src/" }
+        "psr-0": {
+            "Behat\\YiiExtension": "src/",
+            "Behat\\Mink\\Driver": "src/",
+            "WUnit\\Http": "src/",
+            "WUnit\\HttpKernel": "src/"
+        }
     }
 }

--- a/src/Behat/Mink/Driver/WUnitDriver.php
+++ b/src/Behat/Mink/Driver/WUnitDriver.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Behat\Mink\Driver;
+
+use WUnit\HttpKernel\Client;
+use WUnit\Http\YiiKernel;
+
+/*
+ * This file is part of the Behat\Mink.
+ * (c) Patrick Dreyer <patrick@dreyer.name>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * WUnit driver.
+ *
+ * @author Patrick Dreyer <patrick@dreyer.name>
+ */
+class WUnitDriver extends BrowserKitDriver
+{
+    /**
+     * Initializes WUnit driver.
+     *
+     * @param Client $client HttpKernel client instance
+     */
+    public function __construct(Client $client = null)
+    {
+        parent::__construct($client ?: new Client(new YiiKernel()));
+    }
+
+    /**
+     * Sets HTTP Basic authentication parameters
+     *
+     * @param string|Boolean $user     user name or false to disable authentication
+     * @param string         $password password
+     */
+    public function setBasicAuth($user, $password)
+    {
+        $this->getClient()->setAuth($user, $password);
+    }
+
+    /**
+     * Sets specific request header on client.
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public function setRequestHeader($name, $value)
+    {
+        $this->getClient()->setHeader($name, $value);
+    }
+
+    /**
+     * Returns last response headers.
+     *
+     * @return array
+     */
+    public function getResponseHeaders()
+    {
+        return $this->getClient()->getResponse()->getHeaders();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatusCode()
+    {
+        return $this->getClient()->getResponse()->getStatus();
+    }
+
+    /**
+     * Prepares URL for visiting.
+     *
+     * @param string $url
+     *
+     * @return string
+     */
+    protected function prepareUrl($url)
+    {
+        return $url;
+    }
+}

--- a/src/Behat/YiiExtension/services/mink_driver_wunit.xml
+++ b/src/Behat/YiiExtension/services/mink_driver_wunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+
+        <parameter key="behat.mink.driver.wunit.class">Behat\Mink\Driver\WUnitDriver</parameter>
+
+    </parameters>
+    <services>
+
+        <service id="behat.mink.session.wunit" class="%behat.mink.session.class%">
+            <argument type="service">
+                <service class="%behat.mink.driver.wunit.class%">
+                </service>
+            </argument>
+            <argument type="service" id="behat.mink.selector.handler" />
+            <tag name="behat.mink.session" alias="wunit" />
+        </service>
+
+    </services>
+</container>

--- a/src/WUnit/Http/YiiApplication.php
+++ b/src/WUnit/Http/YiiApplication.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @author Weavora Team <hello@weavora.com>
+ * @link http://weavora.com
+ * @copyright Copyright (c) 2011 Weavora LLC
+ */
+
+namespace WUnit\Http;
+
+class YiiApplication extends \CWebApplication {
+
+
+	public function end($status=0, $exit=true) {
+		parent::end(0, false);
+		throw new YiiExitException();
+	}
+}

--- a/src/WUnit/Http/YiiExitException.php
+++ b/src/WUnit/Http/YiiExitException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @author Weavora Team <hello@weavora.com>
+ * @link http://weavora.com
+ * @copyright Copyright (c) 2011 Weavora LLC
+ */
+
+namespace WUnit\Http;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * User: yury.tolochko
+ * Date: 19.01.12
+ * Time: 10:22
+ * To change this template use File | Settings | File Templates.
+ */
+class YiiExitException extends \Exception
+{
+
+}

--- a/src/WUnit/Http/YiiKernel.php
+++ b/src/WUnit/Http/YiiKernel.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @author Weavora Team <hello@weavora.com>
+ * @link http://weavora.com
+ * @copyright Copyright (c) 2011 Weavora LLC
+ */
+
+namespace WUnit\Http;
+
+use WUnit\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+ 
+class YiiKernel implements HttpKernelInterface
+{
+	
+	public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true)
+	{
+		$request->overrideGlobals();
+		$app = \Yii::app();
+		$app->setComponent('request',new YiiRequest());
+		$app->request->inject($request->files->all());
+
+		$hasError = false;
+
+		ob_start();
+		try {
+			$app->processRequest();
+		} catch (YiiExitException $e) {
+
+		} catch (Exception $e) {
+			$hasError = true;
+		}
+
+		$content = ob_get_contents();
+		ob_end_clean();
+
+		$headers = $this->getHeaders();
+		
+		$sessionId = session_id();
+		if(empty($sessionId)){
+			session_regenerate_id();
+			$app->session->open();
+			
+		}
+
+		
+		return new Response($content, $this->getStatusCode($headers, $hasError), $headers);
+	}
+
+	protected function getHeaders()
+	{
+		$rawHeaders = xdebug_get_headers();
+		$headers = array();
+		foreach($rawHeaders as $rawHeader) {
+			list($name, $value) = explode(":", $rawHeader, 2);
+			$name = strtolower(trim($name));
+			$value = trim($value);
+			if (!isset($headers[$name]))
+				$headers[$name] = array();
+
+			$headers[$name][] = $value;
+		}
+		return $headers;
+	}
+
+	protected function getStatusCode($headers, $error = false)
+	{
+		if ($error)
+			return 503;
+
+		if (array_key_exists('location', $headers))
+			return 302;
+
+		return 200;
+	}
+}

--- a/src/WUnit/Http/YiiRequest.php
+++ b/src/WUnit/Http/YiiRequest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @author Weavora Team <hello@weavora.com>
+ * @link http://weavora.com
+ * @copyright Copyright (c) 2011 Weavora LLC
+ */
+
+namespace WUnit\Http;
+
+class YiiRequest extends \CHttpRequest
+{
+
+	public function inject($files = array())
+	{
+
+		$_FILES = $this->filterFiles($files);
+		if (empty($_SERVER['PHP_SELF'])) {
+			$_SERVER['PHP_SELF'] = '/index.php';
+		}
+
+		if (empty($_SERVER['SCRIPT_FILENAME'])) {
+			$_SERVER['SCRIPT_FILENAME'] = \Yii::getPathOfAlias('application') . '/../index.php';
+		}
+	}
+
+	protected function normalizeRequest()
+	{
+		if ($this->enableCsrfValidation)
+			Yii::app()->attachEventHandler('onBeginRequest', array($this, 'validateCsrfToken'));
+	}
+
+	protected function filterFiles($files)
+	{
+		$filtered = array();
+		foreach ($files as $key => $value) {
+			if (is_array($value)) {
+				$filtered[$key] = $this->filterFiles($value);
+			} elseif (is_object($value)) {
+				// Yii style :)
+				$filtered['tmp_name'][$key] = $value->getPathname();
+				$filtered['name'][$key] = $value->getClientOriginalName();
+				$filtered['type'][$key] = $value->getClientMimeType();
+				$filtered['size'][$key] = $value->getClientSize();
+				$filtered['error'][$key] = $value->getError();
+//				$filtered[$key] = array(
+//					'tmp_name' => $value->getPathname(),
+//					'name' => $value->getClientOriginalName(),
+//					'type' => $value->getClientMimeType(),
+//					'size' => $value->getClientSize(),
+//					'error' => $value->getError(),
+//				);
+			}
+		}
+
+		return $filtered;
+	}
+
+}
+

--- a/src/WUnit/HttpKernel/Client.php
+++ b/src/WUnit/HttpKernel/Client.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace WUnit\HttpKernel;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\BrowserKit\Client as BaseClient;
+use Symfony\Component\BrowserKit\Request as DomRequest;
+use Symfony\Component\BrowserKit\Response as DomResponse;
+use Symfony\Component\BrowserKit\Cookie as DomCookie;
+use Symfony\Component\BrowserKit\History;
+use Symfony\Component\BrowserKit\CookieJar;
+
+/**
+ * Client simulates a browser and makes requests to a Kernel object.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @api
+ */
+class Client extends BaseClient
+{
+    protected $kernel;
+
+    /**
+     * Constructor.
+     *
+     * @param HttpKernelInterface $kernel    An HttpKernel instance
+     * @param array               $server    The server parameters (equivalent of $_SERVER)
+     * @param History             $history   A History instance to store the browser history
+     * @param CookieJar           $cookieJar A CookieJar instance to store the cookies
+     */
+    public function __construct(HttpKernelInterface $kernel, array $server = array(), History $history = null, CookieJar $cookieJar = null)
+    {
+        $this->kernel = $kernel;
+
+        parent::__construct($server, $history, $cookieJar);
+
+        $this->followRedirects = true;
+    }
+
+    /**
+     * Makes a request.
+     *
+     * @param Request  $request A Request instance
+     *
+     * @return Response A Response instance
+     */
+    protected function doRequest($request)
+    {
+        return $this->kernel->handle($request);
+    }
+
+    /**
+     * Returns the script to execute when the request must be insulated.
+     *
+     * @param Request $request A Request instance
+     */
+    protected function getScript($request)
+    {
+		$app =  str_replace("'", "\\'", serialize(\Yii::app()));
+		$request = str_replace("'", "\\'", serialize($request));
+		$basePath = dirname(__FILE_) . "/..";
+		$includePaths = get_include_path();
+
+
+		return <<<EOF
+<?php
+
+define('_PHP_INSULATE_', true);
+set_include_path('$includePaths');
+require_once 'bootstrap.php';
+
+\$request = unserialize('$request');
+
+\$kernel = new \WUnit\Http\YiiKernel();
+\$response = \$kernel->handle(\$request);
+echo serialize(\$response);
+EOF;
+    }
+
+    /**
+     * Converts the BrowserKit request to a HttpKernel request.
+     *
+     * @param DomRequest $request A Request instance
+     *
+     * @return Request A Request instance
+     */
+    protected function filterRequest(DomRequest $request)
+    {
+        $httpRequest = Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+
+        $httpRequest->files->replace($this->filterFiles($httpRequest->files->all()));
+
+        return $httpRequest;
+    }
+
+    /**
+     * Filters an array of files.
+     *
+     * This method created test instances of UploadedFile so that the move()
+     * method can be called on those instances.
+     *
+     * If the size of a file is greater than the allowed size (from php.ini) then
+     * an invalid UploadedFile is returned with an error set to UPLOAD_ERR_INI_SIZE.
+     *
+     * @see WUnit\HttpFoundation\File\UploadedFile
+     *
+     * @param array $files An array of files
+     *
+     * @return array An array with all uploaded files marked as already moved
+     */
+    protected function filterFiles(array $files)
+    {
+        $filtered = array();
+        foreach ($files as $key => $value) {
+            if (is_array($value)) {
+                $filtered[$key] = $this->filterFiles($value);
+            } elseif ($value instanceof UploadedFile) {
+                if ($value->isValid() && $value->getSize() > UploadedFile::getMaxFilesize()) {
+                    $filtered[$key] = new UploadedFile(
+                        '',
+                        $value->getClientOriginalName(),
+                        $value->getClientMimeType(),
+                        0,
+                        UPLOAD_ERR_INI_SIZE,
+                        true
+                    );
+                } else {
+                    $filtered[$key] = new UploadedFile(
+                        $value->getPathname(),
+                        $value->getClientOriginalName(),
+                        $value->getClientMimeType(),
+                        $value->getClientSize(),
+                        $value->getError(),
+                        true
+                    );
+                }
+            } else {
+                $filtered[$key] = $value;
+            }
+        }
+
+        return $filtered;
+    }
+
+    /**
+     * Converts the HttpKernel response to a BrowserKit response.
+     *
+     * @param Response $response A Response instance
+     *
+     * @return Response A Response instance
+     */
+    protected function filterResponse($response)
+    {
+        $headers = $response->headers->all();
+        if ($response->headers->getCookies()) {
+            $cookies = array();
+            foreach ($response->headers->getCookies() as $cookie) {
+                $cookies[] = new DomCookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
+            }
+            $headers['Set-Cookie'] = implode(', ', $cookies);
+        }
+
+        return new DomResponse($response->getContent(), $response->getStatusCode(), $headers);
+    }
+}

--- a/src/WUnit/HttpKernel/HttpKernelInterface.php
+++ b/src/WUnit/HttpKernel/HttpKernelInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace WUnit\HttpKernel;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * HttpKernelInterface handles a Request to convert it to a Response.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @api
+ */
+interface HttpKernelInterface
+{
+    const MASTER_REQUEST = 1;
+    const SUB_REQUEST = 2;
+
+    /**
+     * Handles a Request to convert it to a Response.
+     *
+     * When $catch is true, the implementation must catch all exceptions
+     * and do its best to convert them to a Response instance.
+     *
+     * @param  Request $request A Request instance
+     * @param  integer $type    The type of the request
+     *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param  Boolean $catch   Whether to catch exceptions or not
+     *
+     * @return Response A Response instance
+     *
+     * @throws \Exception When an Exception occurs during processing
+     *
+     * @api
+     */
+    function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true);
+}


### PR DESCRIPTION
Looking at Behat/Symfony2Extension, I decided to fully merge the newly created Behat/MinkWUnitDriver into this extension.
Now, the mink driver wunit is loaded either if explicitly requested or Behat/MinkExtension and Behat/MinkBrowserKitDriver is available.
For using it, one still has to configure the behat.yml properly, setting default_session to wunit.
